### PR TITLE
Hook in at after_setup_theme instead of plugins_loaded

### DIFF
--- a/inc/class.rda-remove-access.php
+++ b/inc/class.rda-remove-access.php
@@ -43,7 +43,7 @@ class RDA_Remove_Access {
 
 		$this->settings = $settings;
 
-		add_action( 'plugins_loaded', array( $this, 'is_user_allowed' ) );
+		add_action( 'after_setup_theme', array( $this, 'is_user_allowed' ) );
 	}
 
 	/**


### PR DESCRIPTION
When used with bbPress, enabling debug mode shows this error message: "Notice: bbp_setup_current_user was called incorrectly. The current user is being initialized without using $wp->init(). Please see Debugging in WordPress for more information. (This message was added in version 2.3.) "

Changing the hook seems to maintain the desired functionality, w/o the error message. See also https://core.trac.wordpress.org/ticket/24169